### PR TITLE
feat: add imports, use decorator for exports

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-latest
+          - name: windows
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          target: wasm32-wasi
+          default: true
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.x'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12' 
+
+      - name: Update deps (Linux)
+        run: |
+          go install github.com/extism/cli/extism@latest
+          cd /tmp
+          # get just wasm-merge and wasm-opt
+          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz > binaryen.tar.gz
+          tar xvzf binaryen.tar.gz
+          sudo cp binaryen-version_116/bin/wasm-merge /usr/local/bin
+          sudo cp binaryen-version_116/bin/wasm-opt /usr/local/bin
+        if: runner.os != 'Windows'
+
+      - name: Update deps (Windows)
+        run: |
+          powershell -executionpolicy bypass -File .\install-wasi-sdk.ps1
+          go install github.com/extism/cli/extism@latest
+          Remove-Item -Recurse -Path "c:\Program files\Binaryen" -Force -ErrorAction SilentlyContinue > $null 2>&1
+          New-Item -ItemType Directory -Force -Path "c:\Program files\Binaryen" -ErrorAction Stop > $null 2>&1
+          Invoke-WebRequest -Uri "https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-windows.tar.gz" -OutFile "$env:TMP\binaryen-version_116-x86_64-windows.tar.gz"
+          7z x "$env:TMP\binaryen-version_116-x86_64-windows.tar.gz" -o"$env:TMP\" >$null  2>&1
+          7z x -ttar "$env:TMP\binaryen-version_116-x86_64-windows.tar" -o"$env:TMP\" >$null  2>&1
+          Copy-Item -Path "$env:TMP\binaryen-version_116\bin\wasm-opt.exe" -Destination "c:\Program files\Binaryen" -ErrorAction Stop > $null 2>&1
+          Copy-Item -Path "$env:TMP\binaryen-version_116\bin\wasm-merge.exe" -Destination "c:\Program files\Binaryen" -ErrorAction Stop > $null 2>&1
+        if: runner.os == 'Windows'
+
+      - name: Run Tests (Linux)
+        run: |
+          make
+          make test
+        if: runner.os != 'Windows'
+
+      - name: Run Tests (Windows)
+        run: |
+          set PATH="c:\Program files\Binaryen\";%PATH%
+          make
+          make test
+        shell: cmd
+        if: runner.os == 'Windows'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Update deps (Linux)
         run: |
-          go install github.com/extism/cli/extism@main
+          go install github.com/extism/cli/extism@c1eb1fc
           cd /tmp
           # get just wasm-merge and wasm-opt
           curl -L https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz > binaryen.tar.gz
@@ -45,7 +45,7 @@ jobs:
       - name: Update deps (Windows)
         run: |
           powershell -executionpolicy bypass -File .\install-wasi-sdk.ps1
-          go install github.com/extism/cli/extism@main
+          go install github.com/extism/cli/extism@c1eb1fc
           Remove-Item -Recurse -Path "c:\Program files\Binaryen" -Force -ErrorAction SilentlyContinue > $null 2>&1
           New-Item -ItemType Directory -Force -Path "c:\Program files\Binaryen" -ErrorAction Stop > $null 2>&1
           Invoke-WebRequest -Uri "https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-windows.tar.gz" -OutFile "$env:TMP\binaryen-version_116-x86_64-windows.tar.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
         include:
           - name: linux
             os: ubuntu-latest
-          - name: windows
-            os: windows-latest
+          # - name: windows
+          #   os: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Update deps (Linux)
         run: |
-          go install github.com/extism/cli/extism@latest
+          go install github.com/extism/cli/extism@main
           cd /tmp
           # get just wasm-merge and wasm-opt
           curl -L https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz > binaryen.tar.gz
@@ -45,7 +45,7 @@ jobs:
       - name: Update deps (Windows)
         run: |
           powershell -executionpolicy bypass -File .\install-wasi-sdk.ps1
-          go install github.com/extism/cli/extism@latest
+          go install github.com/extism/cli/extism@main
           Remove-Item -Recurse -Path "c:\Program files\Binaryen" -Force -ErrorAction SilentlyContinue > $null 2>&1
           New-Item -ItemType Directory -Force -Path "c:\Program files\Binaryen" -ErrorAction Stop > $null 2>&1
           Invoke-WebRequest -Uri "https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-windows.tar.gz" -OutFile "$env:TMP\binaryen-version_116-x86_64-windows.tar.gz"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,16 +71,16 @@ jobs:
             asset_name: extism-py-aarch64-macos-${{ github.event.release.tag_name }}
             shasum_cmd: shasum -a 256
             target: aarch64-apple-darwin
-          - name: windows
-            os: windows-latest
-            path: target\x86_64-pc-windows-msvc\release\extism-py.exe
-            asset_name: extism-py-x86_64-windows-${{ github.event.release.tag_name }}
-            target: x86_64-pc-windows-msvc
-          - name: windows-arm64
-            os: windows-latest
-            path: target\aarch64-pc-windows-msvc\release\extism-py.exe
-            asset_name: extism-py-aarch64-windows-${{ github.event.release.tag_name }}
-            target: aarch64-pc-windows-msvc
+          # - name: windows
+          #   os: windows-latest
+          #   path: target\x86_64-pc-windows-msvc\release\extism-py.exe
+          #   asset_name: extism-py-x86_64-windows-${{ github.event.release.tag_name }}
+          #   target: x86_64-pc-windows-msvc
+          # - name: windows-arm64
+          #   os: windows-latest
+          #   path: target\aarch64-pc-windows-msvc\release\extism-py.exe
+          #   asset_name: extism-py-aarch64-windows-${{ github.event.release.tag_name }}
+          #   target: aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,160 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  compile_core:
+    name: Compile Core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          target: wasm32-wasi
+          default: true
+
+      - name: Get wasm-opt
+        run: |
+          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz > binaryen.tar.gz
+          tar xvzf binaryen.tar.gz
+          sudo cp binaryen-version_116/bin/wasm-opt /usr/local/bin
+          sudo chmod +x /usr/local/bin/wasm-opt
+
+      - name: Make core
+        run: make core
+
+      - name: Opt core
+        run: wasm-opt --enable-reference-types --enable-bulk-memory --strip -O3 lib/target/wasm32-wasi/release/core.wasm -o lib/target/wasm32-wasi/release/core.wasm
+
+      - name: Upload core binary to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: engine
+          path: lib/target/wasm32-wasi/release/core.wasm
+
+  compile_cli:
+    name: Compile CLI
+    needs: compile_core
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-latest
+            path: target/x86_64-unknown-linux-gnu/release/extism-py
+            asset_name: extism-py-x86_64-linux-${{ github.event.release.tag_name }}
+            shasum_cmd: sha256sum
+            target: x86_64-unknown-linux-gnu
+          - name: linux-arm64
+            os: ubuntu-latest
+            path: target/aarch64-unknown-linux-gnu/release/extism-py
+            asset_name: extism-py-aarch64-linux-${{ github.event.release.tag_name }}
+            shasum_cmd: sha256sum
+            target: aarch64-unknown-linux-gnu
+          - name: macos
+            os: macos-latest
+            path: target/x86_64-apple-darwin/release/extism-py
+            asset_name: extism-py-x86_64-macos-${{ github.event.release.tag_name }}
+            shasum_cmd: shasum -a 256
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            os: macos-latest
+            path: target/aarch64-apple-darwin/release/extism-py
+            asset_name: extism-py-aarch64-macos-${{ github.event.release.tag_name }}
+            shasum_cmd: shasum -a 256
+            target: aarch64-apple-darwin
+          - name: windows
+            os: windows-latest
+            path: target\x86_64-pc-windows-msvc\release\extism-py.exe
+            asset_name: extism-py-x86_64-windows-${{ github.event.release.tag_name }}
+            target: x86_64-pc-windows-msvc
+          - name: windows-arm64
+            os: windows-latest
+            path: target\aarch64-pc-windows-msvc\release\extism-py.exe
+            asset_name: extism-py-aarch64-windows-${{ github.event.release.tag_name }}
+            target: aarch64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: engine
+          path: bin
+
+      - name: ls
+        run: ls -R
+        working-directory: bin
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          target: ${{ matrix.target }}
+          default: true
+
+      - name: Install gnu gcc
+        run: |
+          sudo apt-get update
+          sudo apt-get install g++-aarch64-linux-gnu
+          sudo apt-get install gcc-aarch64-linux-gnu
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Build CLI ${{ matrix.os }}
+        env:
+          EXTISM_ENGINE_PATH: core.wasm
+        run: cargo build --release --target ${{ matrix.target }} --package extism-py
+
+      - name: Archive assets
+        run: gzip -k -f ${{ matrix.path }} && mv ${{ matrix.path }}.gz ${{ matrix.asset_name }}.gz
+
+      - name: Upload assets to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.asset_name }}.gz
+          path: ${{ matrix.asset_name }}.gz
+
+      - name: Upload assets to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ matrix.asset_name }}.gz
+          asset_name: ${{ matrix.asset_name }}.gz
+          asset_content_type: application/gzip
+
+      - name: Generate asset hash (Linux/MacOS)
+        run: ${{ matrix.shasum_cmd }} ${{ matrix.asset_name }}.gz | awk '{ print $1 }' > ${{ matrix.asset_name }}.gz.sha256
+        if: runner.os != 'Windows'
+
+      - name: Generate asset hash (Windows)
+        run: Get-FileHash -Path ${{ matrix.asset_name }}.gz -Algorithm SHA256 | Select-Object -ExpandProperty Hash > ${{ matrix.asset_name }}.gz.sha256
+        shell: pwsh
+        if: runner.os == 'Windows'
+
+      - name: Upload asset hash to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.asset_name }}.gz.sha256
+          path: ${{ matrix.asset_name }}.gz.sha256
+
+      - name: Upload asset hash to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ matrix.asset_name }}.gz.sha256
+          asset_name: ${{ matrix.asset_name }}.gz.sha256
+          asset_content_type: plain/text
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 extism-py
+examples/*.wasm

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,15 @@ check:
 	uv run ruff check lib/src/prelude.py
 	uv run ruff check bin/src/invoke.py
 	uv run ruff check build.py
+
+core:
+	cd lib && cargo build --release
+
+test: examples
+	EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/count-vowels.wasm count_vowels --wasi --input "this is a test"
+	
+
+.PHONY: examples
+examples: build
+	./extism-py -o examples/count-vowels.wasm examples/count-vowels.py
+	

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ core:
 
 test: examples
 	EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/count-vowels.wasm count_vowels --wasi --input "this is a test"
-	EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/imports.wasm count_vowels --wasi --input "this is a test" --link example=./examples/imports_example.wasm
+	# EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/imports.wasm count_vowels --wasi --input "this is a test" --link example=./examples/imports_example.wasm
 	
 
 .PHONY: examples

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ core:
 
 test: examples
 	EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/count-vowels.wasm count_vowels --wasi --input "this is a test"
-	# EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/imports.wasm count_vowels --wasi --input "this is a test" --link example=./examples/imports_example.wasm
+	EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/imports.wasm count_vowels --wasi --input "this is a test" --link example=./examples/imports_example.wasm
 	
 
 .PHONY: examples

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,12 @@ core:
 
 test: examples
 	EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/count-vowels.wasm count_vowels --wasi --input "this is a test"
+	EXTISM_ENABLE_WASI_OUTPUT=1 extism call ./examples/imports.wasm count_vowels --wasi --input "this is a test" --link example=./examples/imports_example.wasm
 	
 
 .PHONY: examples
 examples: build
 	./extism-py -o examples/count-vowels.wasm examples/count-vowels.py
+	./extism-py -o examples/imports.wasm examples/imports.py
+	./extism-py -o examples/imports_example.wasm examples/imports_example.py
 	

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ check:
 	uv run ruff check bin/src/invoke.py
 	uv run ruff check build.py
 
+clean:
+	rm -rf bin/target lib/target
+
 core:
 	cd lib && cargo build --release
 

--- a/README.md
+++ b/README.md
@@ -169,9 +169,8 @@ Before compiling the compiler, you need to install prerequisites.
 
 1. Install Rust using [rustup](https://rustup.rs)
 2. Install the WASI target platform via `rustup target add --toolchain stable wasm32-wasi`
-3. Install the wasi sdk using the makefile command: `make download-wasi-sdk`
-4. Install [CMake](https://cmake.org/install/) (on macOS with homebrew, `brew install cmake`)
-6. Install [Binaryen](https://github.com/WebAssembly/binaryen/) and add it's install location to your PATH (only wasm-opt is required for build process)
+3. Install [CMake](https://cmake.org/install/) (on macOS with homebrew, `brew install cmake`)
+4. Install [Binaryen](https://github.com/WebAssembly/binaryen/) and add it's install location to your PATH (only wasm-opt is required for build process)
 5. Install [7zip](https://www.7-zip.org/)(only for Windows)
 
 
@@ -180,7 +179,7 @@ Before compiling the compiler, you need to install prerequisites.
 Run make to compile the core crate (the engine) and the cli:
 
 ```
-./build.sh
+./build.py
 ```
 
 To test the built compiler (ensure you have Extism installed):

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Let's write a simple program that exports a `greet` function which will take a n
 ```python
 import extism
 
-__all__ = ["greet"]
-
+@extism.plugin_fn
 def greet():
   name = extism.input_str()
   extism.output_str(f"Hello, {name}")
@@ -54,7 +53,7 @@ def greet():
 
 Some things to note about this code:
 
-1. We can export functions by name using `__all__`. This allows the host to invoke this function. 
+1. We can export functions by name using the `extism.plugin_fn` decorator. This allows the host to invoke this function. 
 3. In this PDK we code directly to the ABI. We get input from the using using `extism.input*` functions and we return data back with the `extism.output*` functions. 
 
 Let's compile this to Wasm now using the `extism-py` tool:
@@ -82,8 +81,7 @@ We catch any exceptions thrown and return them as errors to the host. Suppose we
 ```python
 import extism
 
-__all__ = ["greet"]
-
+@extism.plugin_fn
 def greet():
   name = extism.input_str()
   if name == "Benjamin":
@@ -112,8 +110,7 @@ echo $?
 ```python
 import extism
 
-__all__ = ["sum"]
-
+@extism.plugin_fn
 def sum():
   params = extism.input_json()
   extism.output_json({"sum": params['a'] + params['b']})
@@ -132,8 +129,7 @@ plug-in. These can be useful to statically configure the plug-in with some data 
 ```python
 import extism
 
-__all__ = ["greet"]
-
+@extism.plugin_fn
 def greet():
   user = extism.Config.get("user")
   extism.output_str(f"Hello, {user}!")
@@ -154,8 +150,7 @@ At the current time, calling `console.log` emits an `info` log. Please file an i
 ```python
 import extism
 
-__all__ = ["log_stuff"]
-
+@extism.plugin_fn
 def log_stuff():
   extism.log(Extism.LogLevel.Info, "Hello, world!")
 ```

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -3,12 +3,5 @@ fn main() {
     println!("cargo::rerun-if-changed=../lib/target/wasm32-wasi/release/core.wasm");
 
     let out = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("core.wasm");
-    std::process::Command::new("wasm-opt")
-        .arg("--disable-reference-types")
-        .arg("-O2")
-        .arg("../lib/target/wasm32-wasi/release/core.wasm")
-        .arg("-o")
-        .arg(out)
-        .status()
-        .unwrap();
+    std::fs::copy("../lib/target/wasm32-wasi/release/core.wasm", out).unwrap();
 }

--- a/bin/src/invoke.py
+++ b/bin/src/invoke.py
@@ -2,12 +2,11 @@ import traceback
 
 
 def __invoke(index):
-    global __all__
-    try:
-        return globals()[__all__[index]]()
-    except BaseException as exc:
-        import extism
+    import extism
 
+    try:
+        return extism.__exports[index]()
+    except BaseException as exc:
         tb = "".join(traceback.format_tb(exc.__traceback__))
         err = f"{str(exc)}:\n{tb}"
         extism.ffi.set_error(err)

--- a/bin/src/invoke.py
+++ b/bin/src/invoke.py
@@ -1,11 +1,13 @@
 import traceback
 
 
-def __invoke(index):
+def __invoke(*args):
     import extism
+    index = args[0]
+    a = args[1:]
 
     try:
-        return extism.__exports[index]()
+        return extism.__exports[index](*a)
     except BaseException as exc:
         tb = "".join(traceback.format_tb(exc.__traceback__))
         err = f"{str(exc)}:\n{tb}"

--- a/bin/src/invoke.py
+++ b/bin/src/invoke.py
@@ -3,6 +3,7 @@ import traceback
 
 def __invoke(*args):
     import extism
+
     index = args[0]
     a = args[1:]
 

--- a/bin/src/invoke.py
+++ b/bin/src/invoke.py
@@ -12,15 +12,15 @@ def __invoke(index, shared, *args):
             argnames = f.__code__.co_varnames
             for i, arg in enumerate(args):
                 t = f.__annotations__.get(argnames[i], extism.memory.MemoryHandle)
-                a.append(extism._read(t, arg))
+                a.append(extism._load(t, arg))
         else:
-            a = [extism._alloc(x) for x in args]
+            a = [extism._store(x) for x in args]
 
         res = f(*a)
         if shared and res is not None:
-            return extism._alloc(res)
+            return extism._store(res)
         if res is not None and "return" in f.__annotations__:
-            return extism._read(f.__annotations__["return"], res)
+            return extism._load(f.__annotations__["return"], res)
         else:
             return res
     except BaseException as exc:

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -16,6 +16,7 @@ use std::process::{Command, Stdio};
 const CORE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/core.wasm"));
 const INVOKE: &str = include_str!("invoke.py");
 
+#[derive(Debug, Clone)]
 struct Import {
     module: String,
     name: String,
@@ -71,6 +72,7 @@ fn main() -> Result<(), Error> {
     }
 
     let (imports, exports) = py::find_imports_and_exports(user_code)?;
+    println!("{:?}", imports);
     if exports.is_empty() {
         anyhow::bail!("No exports found, use __all__ to specify exported functions")
     }

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Error> {
     }
 
     let mut user_code = std::fs::read_to_string(&opts.input_py)?;
-    user_code.push_str('\n');
+    user_code.push('\n');
     user_code += INVOKE;
 
     let tmp_dir = TempDir::new()?;

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -9,6 +9,7 @@ use options::Options;
 use structopt::StructOpt;
 use tempfile::TempDir;
 
+use std::borrow::Cow;
 use std::env;
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -41,10 +42,15 @@ fn main() -> Result<(), Error> {
 
     // Parse CLI arguments
     let opts = Options::from_args();
+    let core: Cow<[u8]> = if let Ok(path) = std::env::var("EXTISM_ENGINE_PATH") {
+        Cow::Owned(std::fs::read(path)?)
+    } else {
+        Cow::Borrowed(CORE)
+    };
 
     // Generate core module if `core` flag is set
     if opts.core {
-        opt::Optimizer::new(CORE)
+        opt::Optimizer::new(&core)
             .wizen(true)
             .write_optimized_wasm(opts.output)?;
         return Ok(());

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -70,12 +70,12 @@ fn main() -> Result<(), Error> {
         }
     }
 
-    let exports = py::find_exports(user_code)?;
+    let (imports, exports) = py::find_imports_and_exports(user_code)?;
     if exports.is_empty() {
         anyhow::bail!("No exports found, use __all__ to specify exported functions")
     }
 
-    shim::generate(&exports, &[], &shim_path)?;
+    shim::generate(&exports, &imports, &shim_path)?;
 
     let output = Command::new("wasm-merge")
         .arg("--version")

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Error> {
     }
 
     let mut user_code = std::fs::read_to_string(&opts.input_py)?;
-    user_code.push_str("\n");
+    user_code.push_str('\n');
     user_code += INVOKE;
 
     let tmp_dir = TempDir::new()?;

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -24,6 +24,13 @@ struct Import {
     results: Vec<wagen::ValType>,
 }
 
+#[derive(Debug, Clone)]
+struct Export {
+    name: String,
+    params: Vec<wagen::ValType>,
+    results: Vec<wagen::ValType>,
+}
+
 fn main() -> Result<(), Error> {
     // Setup logging
     let mut builder = env_logger::Builder::new();
@@ -72,9 +79,10 @@ fn main() -> Result<(), Error> {
     }
 
     let (imports, exports) = py::find_imports_and_exports(user_code)?;
-    println!("{:?}", imports);
     if exports.is_empty() {
-        anyhow::bail!("No exports found, use __all__ to specify exported functions")
+        anyhow::bail!(
+            "No exports found, use the @extism.plugin_fn decorator to specify exported functions"
+        )
     }
 
     shim::generate(&exports, &imports, &shim_path)?;

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -28,6 +28,7 @@ struct Import {
 #[derive(Debug, Clone)]
 struct Export {
     name: String,
+    is_plugin_fn: bool,
     params: Vec<wagen::ValType>,
     results: Vec<wagen::ValType>,
 }

--- a/bin/src/opt.rs
+++ b/bin/src/opt.rs
@@ -12,6 +12,10 @@ pub(crate) struct Optimizer<'a> {
 }
 
 fn find_deps() -> PathBuf {
+    if let Ok(path) = std::env::var("EXTISM_PYTHON_USR_DIR") {
+        return PathBuf::from(path);
+    }
+
     let in_repo = PathBuf::from("../lib/target/wasm32-wasi/wasi-deps/usr");
     if in_repo.exists() {
         return in_repo;

--- a/bin/src/opt.rs
+++ b/bin/src/opt.rs
@@ -84,7 +84,7 @@ pub(crate) fn optimize_wasm_file(dest: impl AsRef<Path>) -> Result<(), Error> {
         .arg("--enable-reference-types")
         .arg("--enable-bulk-memory")
         .arg("--strip")
-        .arg("-O3")
+        .arg("-O2")
         .arg(dest.as_ref())
         .arg("-o")
         .arg(dest.as_ref())

--- a/bin/src/py.rs
+++ b/bin/src/py.rs
@@ -24,7 +24,7 @@ fn get_import<R: std::fmt::Debug>(
         }
     }
 
-    // println!("IMPORT {:?}::{:?}: {n_args} -> {has_return}", module, func);
+    println!("IMPORT {:?}::{:?}: {n_args} -> {has_return}", module, func);
     match (module, func) {
         (Some(module), Some(func)) => Ok(Import {
             module,

--- a/bin/src/py.rs
+++ b/bin/src/py.rs
@@ -58,6 +58,7 @@ fn get_export<R: std::fmt::Debug>(
     }
     Ok(Export {
         name: func,
+        is_plugin_fn,
         params: vec![wagen::ValType::I64; n_args],
         results: if is_plugin_fn {
             vec![wagen::ValType::I32]

--- a/bin/src/py.rs
+++ b/bin/src/py.rs
@@ -52,7 +52,7 @@ fn get_import_fn_decorator<R: std::fmt::Debug>(
                     if n.id.as_str() == "import_fn"
                         || n.id.as_str() == "extism" && name.attr.as_str() == "import_fn"
                     {
-                        return get_import(f, call);
+                        return get_import(f, call).map(Some);
                     }
                 }
             }

--- a/bin/src/py.rs
+++ b/bin/src/py.rs
@@ -24,7 +24,7 @@ fn get_import<R: std::fmt::Debug>(
         }
     }
 
-    println!("IMPORT {:?}::{:?}: {n_args} -> {has_return}", module, func);
+    // println!("IMPORT {:?}::{:?}: {n_args} -> {has_return}", module, func);
     match (module, func) {
         (Some(module), Some(func)) => Ok(Import {
             module,

--- a/bin/src/shim.rs
+++ b/bin/src/shim.rs
@@ -62,9 +62,15 @@ pub(crate) fn generate(
             for _ in 0..p {
                 params.push(ValType::I64);
             }
+            println!(
+                "INVOKE HOST FN: {name}: {:?}, {:?}",
+                params,
+                vec![ValType::I64; q]
+            );
             let invoke_host = module
                 .func(&name, params, vec![ValType::I64; q], [])
                 .export(&name);
+
             let builder = invoke_host.builder();
             for i in 1..=p {
                 builder.push(Instr::LocalGet(i as u32));
@@ -74,6 +80,7 @@ pub(crate) fn generate(
                 ty: indirect_type,
                 table: import_table,
             });
+            builder.push(Instr::Return);
         }
     }
     module.active_element(

--- a/bin/src/shim.rs
+++ b/bin/src/shim.rs
@@ -2,7 +2,7 @@ use crate::*;
 use wagen::{Instr, ValType};
 
 pub(crate) fn generate(
-    exports: &[String],
+    exports: &[Export],
     imports: &[Import],
     shim_path: &std::path::Path,
 ) -> Result<(), Error> {
@@ -18,12 +18,17 @@ pub(crate) fn generate(
     let mut elements = vec![];
     for (index, export) in exports.iter().enumerate() {
         let fn_index = module
-            .func(&export, [], [wagen::ValType::I32], [])
+            .func(
+                &export.name,
+                export.params.clone(),
+                export.results.clone(),
+                [],
+            )
             .with_builder(|b| {
                 b.push(wagen::Instr::I32Const(index as i32));
                 b.push(wagen::Instr::Call(invoke.index()));
             })
-            .export(export);
+            .export(&export.name);
         elements.push(fn_index.index);
     }
 

--- a/bin/src/shim.rs
+++ b/bin/src/shim.rs
@@ -22,13 +22,19 @@ pub(crate) fn generate(
     let __arg_f32 = module.import("core", "__arg_f32", None, [ValType::F32], []);
     let __arg_f64 = module.import("core", "__arg_f64", None, [ValType::F64], []);
 
-    let __invoke = module.import("core", "__invoke", None, [wagen::ValType::I32], []);
+    let __invoke = module.import(
+        "core",
+        "__invoke",
+        None,
+        [wagen::ValType::I32, wagen::ValType::I32],
+        [],
+    );
 
     let __invoke_i64 = module.import(
         "core",
         "__invoke_i64",
         None,
-        [wagen::ValType::I32],
+        [wagen::ValType::I32, wagen::ValType::I32],
         [wagen::ValType::I64],
     );
 
@@ -36,7 +42,7 @@ pub(crate) fn generate(
         "core",
         "__invoke_i32",
         None,
-        [wagen::ValType::I32],
+        [wagen::ValType::I32, wagen::ValType::I32],
         [wagen::ValType::I32],
     );
 
@@ -123,6 +129,7 @@ pub(crate) fn generate(
         }
 
         builder.push(Instr::I32Const(index as i32));
+        builder.push(Instr::I32Const(!export.is_plugin_fn as i32));
         match export.results.first() {
             None => {
                 builder.push(Instr::Call(__invoke.index()));

--- a/bin/src/shim.rs
+++ b/bin/src/shim.rs
@@ -92,7 +92,7 @@ pub(crate) fn generate(
             .export(&export.name);
         let builder = func.builder();
         builder.push(Instr::Call(__arg_start.index()));
-        for (parami, param) in export.params.clone().into_iter().enumerate() {
+        for (parami, param) in export.params.iter().enumerate() {
             builder.push(Instr::LocalGet(parami as u32));
 
             match param {

--- a/bin/src/shim.rs
+++ b/bin/src/shim.rs
@@ -52,6 +52,11 @@ pub(crate) fn generate(
         import_elements.push(index.index());
     }
 
+    module.active_element(
+        Some(import_table),
+        wagen::Elements::Functions(&import_elements),
+    );
+
     for p in 0..=5 {
         for q in 0..=1 {
             let indirect_type = module
@@ -62,11 +67,6 @@ pub(crate) fn generate(
             for _ in 0..p {
                 params.push(ValType::I64);
             }
-            println!(
-                "INVOKE HOST FN: {name}: {:?}, {:?}",
-                params,
-                vec![ValType::I64; q]
-            );
             let invoke_host = module
                 .func(&name, params, vec![ValType::I64; q], [])
                 .export(&name);
@@ -83,10 +83,6 @@ pub(crate) fn generate(
             builder.push(Instr::Return);
         }
     }
-    module.active_element(
-        Some(import_table),
-        wagen::Elements::Functions(&import_elements),
-    );
 
     for (index, export) in exports.iter().enumerate() {
         let func = module
@@ -144,6 +140,6 @@ pub(crate) fn generate(
         }
     }
 
-    module.validate_save(&shim_path)?;
+    module.validate_save(shim_path)?;
     Ok(())
 }

--- a/bin/src/shim.rs
+++ b/bin/src/shim.rs
@@ -47,7 +47,6 @@ pub(crate) fn generate(
         );
         import_items.push((format!("{}_{}", import.module, import.name), index));
     }
-    import_items.sort_by_key(|x| x.0.to_string());
 
     for (_f, index) in import_items {
         import_elements.push(index.index());

--- a/examples/count-vowels.py
+++ b/examples/count-vowels.py
@@ -1,8 +1,7 @@
-__all__ = ["count_vowels"]
-
 import extism
 import json
 
+@extism.plugin_fn
 def count_vowels():
     input = extism.input_str()
     total = 0

--- a/examples/imports.py
+++ b/examples/imports.py
@@ -9,6 +9,10 @@ def do_something():
 def reflect(x: str) -> str:
     pass
 
+@extism.import_fn("example", "update_dict")
+def update_dict(x: dict) -> dict:
+    pass
+
 @extism.plugin_fn
 def count_vowels():
     input = reflect(extism.input_str())
@@ -18,5 +22,5 @@ def count_vowels():
         if ch in ['A', 'a', 'E', 'e', 'I', 'i', 'O', 'o', 'U', 'u']:
             total += 1
     extism.log(extism.LogLevel.Info, "Hello!")
-    extism.output_json({"count": total})
+    extism.output_json(update_dict({"count": total}))
 

--- a/examples/imports.py
+++ b/examples/imports.py
@@ -1,0 +1,22 @@
+import extism
+import json
+
+@extism.import_fn("example", "do_something")
+def do_something():
+    pass
+
+@extism.import_fn("example", "reflect")
+def reflect(x: str) -> str:
+    pass
+
+@extism.plugin_fn
+def count_vowels():
+    input = reflect(extism.input_str())
+    do_something()
+    total = 0
+    for ch in input:
+        if ch in ['A', 'a', 'E', 'e', 'I', 'i', 'O', 'o', 'U', 'u']:
+            total += 1
+    extism.log(extism.LogLevel.Info, "Hello!")
+    extism.output_json({"count": total})
+

--- a/examples/imports_example.py
+++ b/examples/imports_example.py
@@ -7,3 +7,8 @@ def do_something():
 @extism.shared_fn
 def reflect(x: str) -> str:
     return x
+
+@extism.shared_fn
+def update_dict(d: dict) -> dict:
+    d["abc"] = 123
+    return d

--- a/examples/imports_example.py
+++ b/examples/imports_example.py
@@ -1,0 +1,9 @@
+import extism
+
+@extism.shared_fn
+def do_something():
+    print("Something")
+
+@extism.shared_fn
+def reflect(x: str) -> str:
+    return x

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -1,4 +1,5 @@
 fn main() {
     use wlr_libpy::bld_cfg::configure_static_libs;
     configure_static_libs().unwrap().emit_link_flags();
+    println!("cargo::rerun-if-changed=src/prelude.py");
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -122,7 +122,6 @@ pub extern "C" fn __arg_f64(arg: f64) {
 
 #[export_name = "wizer.initialize"]
 extern "C" fn init() {
-    println!("{:?}", std::env::var("PYTHONPATH"));
     append_to_inittab!(make_extism_ffi_module);
     pyo3::prepare_freethreaded_python();
     let mut code = String::new();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,7 +16,7 @@ fn convert_arg(py: Python, arg: Arg) -> PyObject {
 }
 
 #[no_mangle]
-pub extern "C" fn __invoke(index: u32) {
+pub extern "C" fn __invoke(index: u32, shared: bool) {
     Python::with_gil(|py| -> PyResult<()> {
         let call_args = unsafe { CALL_ARGS.pop() };
         let mut args: Vec<PyObject> = call_args
@@ -24,6 +24,7 @@ pub extern "C" fn __invoke(index: u32) {
             .into_iter()
             .map(|x| convert_arg(py, x))
             .collect();
+        args.insert(0, shared.to_object(py));
         args.insert(0, index.to_object(py));
         let args = PyTuple::new_bound(py, args);
         let m = PyModule::import_bound(py, "extism_plugin")?;
@@ -35,7 +36,7 @@ pub extern "C" fn __invoke(index: u32) {
 }
 
 #[no_mangle]
-pub extern "C" fn __invoke_i32(index: u32) -> i32 {
+pub extern "C" fn __invoke_i32(index: u32, shared: bool) -> i32 {
     Python::with_gil(|py| -> PyResult<i32> {
         let call_args = unsafe { CALL_ARGS.pop() };
         let mut args: Vec<PyObject> = call_args
@@ -43,6 +44,7 @@ pub extern "C" fn __invoke_i32(index: u32) -> i32 {
             .into_iter()
             .map(|x| convert_arg(py, x))
             .collect();
+        args.insert(0, shared.to_object(py));
         args.insert(0, index.to_object(py));
         let args = PyTuple::new_bound(py, args);
         let m = PyModule::import_bound(py, "extism_plugin")?;
@@ -57,7 +59,7 @@ pub extern "C" fn __invoke_i32(index: u32) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn __invoke_i64(index: u32) -> i64 {
+pub extern "C" fn __invoke_i64(index: u32, shared: bool) -> i64 {
     Python::with_gil(|py| -> PyResult<i64> {
         let call_args = unsafe { CALL_ARGS.pop() };
         let mut args: Vec<PyObject> = call_args
@@ -65,6 +67,7 @@ pub extern "C" fn __invoke_i64(index: u32) -> i64 {
             .into_iter()
             .map(|x| convert_arg(py, x))
             .collect();
+        args.insert(0, shared.to_object(py));
         args.insert(0, index.to_object(py));
         let args = PyTuple::new_bound(py, args);
         let m = PyModule::import_bound(py, "extism_plugin")?;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -8,7 +8,7 @@ use std::io::Read;
 
 const PRELUDE: &str = include_str!("prelude.py");
 
-fn convert_arg<'a>(py: Python<'a>, arg: Arg) -> PyObject {
+fn convert_arg(py: Python, arg: Arg) -> PyObject {
     match arg {
         Arg::Int(x) => x.to_object(py),
         Arg::Float(f) => f.to_object(py),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,5 @@
-use pyo3::types::PyModule;
-use pyo3::{append_to_inittab, prelude::*, Py, PyAny, PyResult, Python};
+use pyo3::types::{PyModule, PyTuple};
+use pyo3::{append_to_inittab, conversion::ToPyObject, prelude::*, Py, PyAny, PyResult, Python};
 
 mod py_module;
 use py_module::make_extism_ffi_module;
@@ -8,18 +8,116 @@ use std::io::Read;
 
 const PRELUDE: &str = include_str!("prelude.py");
 
+fn convert_arg<'a>(py: Python<'a>, arg: Arg) -> PyObject {
+    match arg {
+        Arg::Int(x) => x.to_object(py),
+        Arg::Float(f) => f.to_object(py),
+    }
+}
+
 #[no_mangle]
-pub extern "C" fn __invoke(index: i32) -> i32 {
-    Python::with_gil(|py| -> PyResult<i32> {
+pub extern "C" fn __invoke(index: u32) {
+    Python::with_gil(|py| -> PyResult<()> {
+        let call_args = unsafe { CALL_ARGS.pop() };
+        let mut args: Vec<PyObject> = call_args
+            .unwrap()
+            .into_iter()
+            .map(|x| convert_arg(py, x))
+            .collect();
+        args.insert(0, index.to_object(py));
+        let args = PyTuple::new_bound(py, args);
         let m = PyModule::import_bound(py, "extism_plugin")?;
         let fun: Py<PyAny> = m.getattr("__invoke")?.into();
-        let res = fun.call1(py, (index,))?;
+        fun.call1(py, args)?;
+        Ok(())
+    })
+    .unwrap()
+}
+
+#[no_mangle]
+pub extern "C" fn __invoke_i32(index: u32) -> i32 {
+    Python::with_gil(|py| -> PyResult<i32> {
+        let call_args = unsafe { CALL_ARGS.pop() };
+        let mut args: Vec<PyObject> = call_args
+            .unwrap()
+            .into_iter()
+            .map(|x| convert_arg(py, x))
+            .collect();
+        args.insert(0, index.to_object(py));
+        let args = PyTuple::new_bound(py, args);
+        let m = PyModule::import_bound(py, "extism_plugin")?;
+        let fun: Py<PyAny> = m.getattr("__invoke")?.into();
+        let res = fun.call1(py, args)?;
         if let Ok(res) = res.extract(py) {
             return Ok(res);
         }
         Ok(0)
     })
     .unwrap()
+}
+
+#[no_mangle]
+pub extern "C" fn __invoke_i64(index: u32) -> i64 {
+    Python::with_gil(|py| -> PyResult<i64> {
+        let call_args = unsafe { CALL_ARGS.pop() };
+        let mut args: Vec<PyObject> = call_args
+            .unwrap()
+            .into_iter()
+            .map(|x| convert_arg(py, x))
+            .collect();
+        args.insert(0, index.to_object(py));
+        let args = PyTuple::new_bound(py, args);
+        let m = PyModule::import_bound(py, "extism_plugin")?;
+        let fun: Py<PyAny> = m.getattr("__invoke")?.into();
+        let res = fun.call1(py, args)?;
+        if let Ok(res) = res.extract(py) {
+            return Ok(res);
+        }
+        Ok(0)
+    })
+    .unwrap()
+}
+
+enum Arg {
+    Int(i64),
+    Float(f64),
+}
+
+static mut CALL_ARGS: Vec<Vec<Arg>> = vec![];
+
+#[no_mangle]
+pub extern "C" fn __arg_start() {
+    unsafe {
+        CALL_ARGS.push(vec![]);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn __arg_i32(arg: i32) {
+    unsafe {
+        CALL_ARGS.last_mut().unwrap().push(Arg::Int(arg as i64));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn __arg_i64(arg: i64) {
+    unsafe {
+        CALL_ARGS.last_mut().unwrap().push(Arg::Int(arg));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn __arg_f32(arg: f32) {
+    unsafe {
+        CALL_ARGS.last_mut().unwrap().push(Arg::Float(arg as f64));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn __arg_f64(arg: f64) {
+    unsafe {
+        CALL_ARGS.last_mut().unwrap().push(Arg::Float(arg));
+    }
 }
 
 #[export_name = "wizer.initialize"]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -122,6 +122,7 @@ pub extern "C" fn __arg_f64(arg: f64) {
 
 #[export_name = "wizer.initialize"]
 extern "C" fn init() {
+    println!("{:?}", std::env::var("PYTHONPATH"));
     append_to_inittab!(make_extism_ffi_module);
     pyo3::prepare_freethreaded_python();
     let mut code = String::new();

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -15,19 +15,46 @@ HttpRequest = ffi.HttpRequest
 
 IMPORT_INDEX = 0
 
+__exports = []
+
+
 def import_fn(module, name):
     global IMPORT_INDEX
     idx = IMPORT_INDEX
-    def inner(func):       
+
+    def inner(func):
         def wrapper(*args):
             print(f"CALL IMPORT {idx}: {module}::{name}")
-            if 'return' in func.__annotations__:
+            if "return" in func.__annotations__:
                 ffi.__invoke_host_func(idx, *args)
             else:
                 ffi.__invoke_host_func0(idx, *args)
+
         return wrapper
+
     IMPORT_INDEX += 1
     return inner
+
+
+def plugin_fn(func):
+    global __exports
+    __exports.append(func)
+
+    def inner():
+        return func()
+
+    return inner
+
+
+def shared_fn(func):
+    global __exports
+    __exports.append(func)
+
+    def inner(*args, **kw):
+        return func(*args, **kw)
+
+    return inner
+
 
 def input_json():
     return json.loads(input_str())

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -25,8 +25,10 @@ def import_fn(module, name):
         def wrapper(*args):
             print(f"CALL IMPORT {idx}: {module}::{name}")
             if "return" in func.__annotations__:
+                print("WITH RETURN")
                 ffi.__invoke_host_func(idx, *args)
             else:
+                print("NO RETURN")
                 ffi.__invoke_host_func0(idx, *args)
 
         return wrapper

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -12,9 +12,9 @@ output_bytes = ffi.output_bytes
 
 HttpRequest = ffi.HttpRequest
 
-IMPORT_INDEX = 0
-
 __exports = []
+
+IMPORT_INDEX = 0
 
 
 class Codec:
@@ -77,20 +77,17 @@ def import_fn(module, name):
 
     def inner(func):
         def wrapper(*args):
-            print("ARGS", args)
             args = [_alloc(a) for a in args]
             if "return" in func.__annotations__:
                 ret = func.__annotations__["return"]
                 print("RETURN", func, ret, module, name, idx, args)
                 res = ffi.__invoke_host_func(idx, *args)
-                print("AFTER")
                 return _read(ret, res)
             else:
                 print("NO RETURN", func, module, name, idx, args)
                 ffi.__invoke_host_func0(idx, *args)
 
         return wrapper
-
     IMPORT_INDEX += 1
     return inner
 

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -86,7 +86,7 @@ def import_fn(module, name):
                 print("AFTER")
                 return _read(ret, res)
             else:
-                print("NO RETURN", module, name, idx, args)
+                print("NO RETURN", func, module, name, idx, args)
                 ffi.__invoke_host_func0(idx, *args)
 
         return wrapper

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -1,5 +1,7 @@
 from typing import Union, Optional
+
 import json
+from functools import wraps
 import extism_ffi as ffi
 
 LogLevel = ffi.LogLevel
@@ -11,6 +13,18 @@ output_bytes = ffi.output_bytes
 
 HttpRequest = ffi.HttpRequest
 
+IMPORT_INDEX = 0
+
+def import_fn(module, name):
+    global IMPORT_INDEX
+    idx = IMPORT_INDEX
+    def inner(func):       
+        def wrapper(*args):
+            print(f"CALL IMPORT {idx}: {module}::{name}")
+            # ffi.__invoke_host_func(idx, *args) 
+        return wrapper
+    IMPORT_INDEX += 1
+    return inner
 
 def input_json():
     return json.loads(input_str())

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -19,14 +19,28 @@ IMPORT_INDEX = 0
 
 
 class Codec:
+    """
+    Codec is used to serialize and deserialize values in Extism memory
+    """
+
     def __init__(self, value):
         self.value = value
 
+    def get(self):
+        """Method to get the inner value"""
+        return self.value
+
+    def set(self, x):
+        """Method to set in the inner value"""
+        self.value = x
+
     def encode(self) -> bytes:
+        """Encode the inner value to bytes"""
         raise Exception("encode not implemented")
 
     @staticmethod
     def decode(s: bytes):
+        """Decode a value from bytes"""
         raise Exception("encode not implemented")
 
 
@@ -39,56 +53,61 @@ class Json(Codec):
         return Json(json.loads(s.decode()))
 
 
-def _alloc(x):
+def _store(x) -> int:
     if isinstance(x, str):
         return ffi.memory.alloc(x.encode()).offset
     elif isinstance(x, bytes):
         return ffi.memory.alloc(x).offset
-    elif isinstance(x, dict):
+    elif isinstance(x, dict) or isinstance(x, list):
         return ffi.memory.alloc(json.dumps(x).encode()).offset
     elif isinstance(x, Codec):
         return ffi.memory.alloc(x.encode()).offset
     elif isinstance(x, ffi.memory.MemoryHandle):
-        return a.offset
+        return x.offset
     elif isinstance(x, int):
         return x
+    elif x is None:
+        return 0
     else:
         raise Exception(f"Unsupported python type: {type(x)}")
 
 
-def _read(t, x):
-    if t == int:
+def _load(t, x):
+    if t is int:
         return x
 
     mem = ffi.memory.find(x)
     if mem is None:
         return None
 
-    if t == str:
+    if t is str:
         return ffi.memory.string(mem)
-    elif t == bytes:
+    elif t is bytes:
         return ffi.memory.bytes(mem)
-    elif t == dict:
+    elif t is dict or t is list:
         return json.loads(ffi.memory.string(mem))
-    elif t == Json:
-        return Json.decode(ffi.memory.bytes(mem))
-    elif t == ffi.memory.MemoryHandle:
+    elif issubclass(t, Codec):
+        return t.decode(ffi.memory.bytes(mem))
+    elif t is ffi.memory.MemoryHandle:
         return mem
+    elif t is type(None):
+        return None
     else:
         raise Exception(f"Unsupported python type: {t}")
 
 
 def import_fn(module, name):
+    """Annotate an import function"""
     global IMPORT_INDEX
     idx = IMPORT_INDEX
 
     def inner(func):
         def wrapper(*args):
-            args = [_alloc(a) for a in args]
+            args = [_store(a) for a in args]
             if "return" in func.__annotations__:
                 ret = func.__annotations__["return"]
                 res = ffi.__invoke_host_func(idx, *args)
-                return _read(ret, res)
+                return _load(ret, res)
             else:
                 ffi.__invoke_host_func0(idx, *args)
 
@@ -99,6 +118,7 @@ def import_fn(module, name):
 
 
 def plugin_fn(func):
+    """Annotate a function that will be called by Extism"""
     global __exports
     __exports.append(func)
 
@@ -109,6 +129,7 @@ def plugin_fn(func):
 
 
 def shared_fn(f):
+    """Annotate a an export that won't be called directly by Extism"""
     global __exports
     __exports.append(f)
 
@@ -119,20 +140,24 @@ def shared_fn(f):
 
 
 def input_json():
+    """Get input as JSON"""
     return json.loads(input_str())
 
 
 def output_json(x):
+    """Set JSON output"""
     output_str(json.dumps(x))
 
 
 class Var:
     @staticmethod
     def get_bytes(key: str) -> Optional[bytes]:
+        """Get variable as bytes"""
         return ffi.var_get(key)
 
     @staticmethod
     def get_str(key: str) -> Optional[str]:
+        """Get variable as string"""
         x = ffi.var_get(key)
         if x is None:
             return None
@@ -140,6 +165,7 @@ class Var:
 
     @staticmethod
     def get_json(key: str):
+        """Get variable as JSON"""
         x = Var.get_str(key)
         if x is None:
             return x
@@ -147,6 +173,7 @@ class Var:
 
     @staticmethod
     def set(key: str, value: Union[bytes, str]):
+        """Set a variable with a string or bytes value"""
         if isinstance(value, str):
             value = value.encode()
         return ffi.var_set(key, value)
@@ -154,11 +181,13 @@ class Var:
 
 class Config:
     @staticmethod
-    def get(key: str) -> Optional[str]:
+    def get_str(key: str) -> Optional[str]:
+        """Get a config value as string"""
         return ffi.config_get(key)
 
     @staticmethod
     def get_json(key: str):
+        """Get a config vakye as JSON"""
         x = ffi.config_get(key)
         if x is None:
             return None
@@ -173,15 +202,19 @@ class HttpResponse:
 
     @property
     def status_code(self):
+        """Get HTTP status code"""
         return self._inner.status_code()
 
     def data_bytes(self):
+        """Get response body bytes"""
         return self._inner.data()
 
     def data_str(self):
+        """Get response body string"""
         return self.data_bytes().decode()
 
     def data_json(self):
+        """Get response body JSON"""
         return json.loads(self.data_str())
 
 
@@ -193,6 +226,7 @@ class Http:
         body: Optional[Union[bytes, str]] = None,
         headers: Optional[dict] = None,
     ) -> HttpResponse:
+        """Make an HTTP request"""
         req = HttpRequest(url, meth, headers or {})
         if body is not None and isinstance(body, str):
             body = body.encode()

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -80,11 +80,9 @@ def import_fn(module, name):
             args = [_alloc(a) for a in args]
             if "return" in func.__annotations__:
                 ret = func.__annotations__["return"]
-                print("RETURN", func, ret, module, name, idx, args)
                 res = ffi.__invoke_host_func(idx, *args)
                 return _read(ret, res)
             else:
-                print("NO RETURN", func, module, name, idx, args)
                 ffi.__invoke_host_func0(idx, *args)
 
         return wrapper

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -21,7 +21,10 @@ def import_fn(module, name):
     def inner(func):       
         def wrapper(*args):
             print(f"CALL IMPORT {idx}: {module}::{name}")
-            ffi.__invoke_host_func(idx, *args) 
+            if 'return' in func.__annotations__:
+                ffi.__invoke_host_func(idx, *args)
+            else:
+                ffi.__invoke_host_func0(idx, *args)
         return wrapper
     IMPORT_INDEX += 1
     return inner

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -21,7 +21,7 @@ def import_fn(module, name):
     def inner(func):       
         def wrapper(*args):
             print(f"CALL IMPORT {idx}: {module}::{name}")
-            # ffi.__invoke_host_func(idx, *args) 
+            ffi.__invoke_host_func(idx, *args) 
         return wrapper
     IMPORT_INDEX += 1
     return inner

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -43,6 +43,8 @@ def _alloc(x):
         return ffi.memory.alloc(x.encode()).offset
     elif isinstance(x, bytes):
         return ffi.memory.alloc(x).offset
+    elif isinstance(x, dict):
+        return ffi.memory.alloc(json.dumps(x)).offset
     elif isinstance(x, Codec):
         return ffi.memory.alloc(x.encode()).offset
     elif isinstance(x, ffi.memory.MemoryHandle):
@@ -65,8 +67,12 @@ def _read(t, x):
         return ffi.memory.string(mem)
     elif t == bytes:
         return ffi.memory.bytes(mem)
+    elif t == dict:
+        return json.loads(ffi.memory.string(mem))
     elif t == Json:
         return Json.decode(ffi.memory.bytes(mem))
+    elif t == ffi.memory.MemoryHandle:
+        return mem
     else:
         raise Exception(f"Unsupported python type: {t}")
 

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -1,7 +1,6 @@
 from typing import Union, Optional
 
 import json
-from functools import wraps
 import extism_ffi as ffi
 
 LogLevel = ffi.LogLevel

--- a/lib/src/py_module.rs
+++ b/lib/src/py_module.rs
@@ -1,7 +1,7 @@
 use pyo3::{
     exceptions::PyException,
     prelude::*,
-    types::{PyBytes, PyModule, PyTuple},
+    types::{PyBytes, PyInt, PyModule, PyTuple},
     PyErr, PyResult,
 };
 
@@ -226,11 +226,11 @@ pub fn memory_alloc(data: &[u8]) -> PyResult<MemoryHandle> {
 }
 
 #[pyfunction]
-#[pyo3(signature = (index, *args))]
+#[pyo3(signature = (i, *args))]
 #[pyo3(name = "__invoke_host_func")]
-fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<MemoryHandle>> {
+fn invoke_host_func(i: &Bound<'_, PyInt>, args: &Bound<'_, PyTuple>) -> PyResult<u64> {
     let length = args.len();
-
+    let index = i.extract::<'_, u32>()?;
     let offs = unsafe {
         match length {
             0 => __invokeHostFunc_0_1(index),
@@ -269,22 +269,15 @@ fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<Me
         }
     };
 
-    println!("OFFS: {offs}");
-    if let Some(mem) = extism_pdk::Memory::find(offs) {
-        Ok(Some(MemoryHandle {
-            offset: mem.offset(),
-            length: mem.len() as u64,
-        }))
-    } else {
-        Ok(None)
-    }
+    Ok(offs)
 }
 
 #[pyfunction]
 #[pyo3(signature = (index, *args))]
 #[pyo3(name = "__invoke_host_func0")]
-fn invoke_host_func0(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<()> {
+fn invoke_host_func0(index: &Bound<'_, PyInt>, args: &Bound<'_, PyTuple>) -> PyResult<()> {
     let length = args.len();
+    let index = index.extract::<'_, u32>()?;
 
     unsafe {
         match length {

--- a/lib/src/py_module.rs
+++ b/lib/src/py_module.rs
@@ -230,7 +230,6 @@ pub fn memory_alloc(data: &[u8]) -> PyResult<MemoryHandle> {
 #[pyo3(name = "__invoke_host_func")]
 fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<MemoryHandle>> {
     let length = args.len();
-    println!("__invoke_host_func: {index}");
 
     let offs = unsafe {
         match length {
@@ -285,8 +284,6 @@ fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<Me
 #[pyo3(name = "__invoke_host_func0")]
 fn invoke_host_func0(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<()> {
     let length = args.len();
-
-    println!("__invoke_host_func0: {index}");
 
     unsafe {
         match length {

--- a/lib/src/py_module.rs
+++ b/lib/src/py_module.rs
@@ -269,6 +269,7 @@ fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<Me
         }
     };
 
+    println!("OFFS: {offs}");
     if let Some(mem) = extism_pdk::Memory::find(offs) {
         Ok(Some(MemoryHandle {
             offset: mem.offset(),

--- a/lib/src/py_module.rs
+++ b/lib/src/py_module.rs
@@ -230,7 +230,7 @@ pub fn memory_alloc(data: &[u8]) -> PyResult<MemoryHandle> {
 #[pyo3(name = "__invoke_host_func")]
 fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<MemoryHandle>> {
     let length = args.len();
-
+    println!("INVOKE HOST INDEX: {}", index);
     let offs = unsafe {
         match length {
             0 => __invokeHostFunc_0_1(index),

--- a/lib/src/py_module.rs
+++ b/lib/src/py_module.rs
@@ -37,7 +37,7 @@ pub fn output_str(result: &str) -> PyResult<()> {
 
 #[pyo3::pyfunction]
 pub fn set_error(msg: &str) -> PyResult<()> {
-    let mem = extism_pdk::Memory::from_bytes(&msg).map_err(error)?;
+    let mem = extism_pdk::Memory::from_bytes(msg).map_err(error)?;
     unsafe {
         extism_pdk::extism::error_set(mem.offset());
     }
@@ -218,7 +218,7 @@ pub fn memory_free(mem: MemoryHandle) -> PyResult<()> {
 #[pyo3::pyfunction]
 #[pyo3(name = "alloc")]
 pub fn memory_alloc(data: &[u8]) -> PyResult<MemoryHandle> {
-    let mem = extism_pdk::Memory::from_bytes(&data).map_err(error)?;
+    let mem = extism_pdk::Memory::from_bytes(data).map_err(error)?;
     Ok(MemoryHandle {
         offset: mem.offset(),
         length: mem.len() as u64,

--- a/lib/src/py_module.rs
+++ b/lib/src/py_module.rs
@@ -1,7 +1,7 @@
 use pyo3::{
     exceptions::PyException,
     prelude::*,
-    types::{PyBytes, PyList, PyListMethods, PyModule},
+    types::{PyBytes, PyModule, PyTuple},
     PyErr, PyResult,
 };
 
@@ -228,7 +228,7 @@ pub fn memory_alloc(data: &[u8]) -> PyResult<MemoryHandle> {
 #[pyfunction]
 #[pyo3(signature = (index, *args))]
 #[pyo3(name = "__invoke_host_func")]
-fn invoke_host_func(index: u32, args: &Bound<'_, PyList>) -> PyResult<Option<MemoryHandle>> {
+fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<MemoryHandle>> {
     let length = args.len();
 
     let offs = unsafe {
@@ -282,7 +282,7 @@ fn invoke_host_func(index: u32, args: &Bound<'_, PyList>) -> PyResult<Option<Mem
 #[pyfunction]
 #[pyo3(signature = (index, *args))]
 #[pyo3(name = "__invoke_host_func0")]
-fn invoke_host_func0(index: u32, args: &Bound<'_, PyList>) -> PyResult<()> {
+fn invoke_host_func0(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<()> {
     let length = args.len();
 
     unsafe {

--- a/lib/src/py_module.rs
+++ b/lib/src/py_module.rs
@@ -230,7 +230,8 @@ pub fn memory_alloc(data: &[u8]) -> PyResult<MemoryHandle> {
 #[pyo3(name = "__invoke_host_func")]
 fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<MemoryHandle>> {
     let length = args.len();
-    println!("INVOKE HOST INDEX: {}", index);
+    println!("__invoke_host_func: {index}");
+
     let offs = unsafe {
         match length {
             0 => __invokeHostFunc_0_1(index),
@@ -284,6 +285,8 @@ fn invoke_host_func(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<Option<Me
 #[pyo3(name = "__invoke_host_func0")]
 fn invoke_host_func0(index: u32, args: &Bound<'_, PyTuple>) -> PyResult<()> {
     let length = args.len();
+
+    println!("__invoke_host_func0: {index}");
 
     unsafe {
         match length {


### PR DESCRIPTION
Closes #4
Closes #5
Closes #6

- Adds ability to call imports
- Converts exports from being specified using `__all__` to using the `plugin_fn` decorator
- Also adds CI