### PR TITLE
Experiment: Dynamic Linking of core

### DIFF
--- a/bin/src/shim.rs
+++ b/bin/src/shim.rs
@@ -4,8 +4,10 @@ use wagen::{Instr, ValType};
 pub(crate) fn generate(
     exports: &[String],
     imports: &[Import],
-    shim_path: &std::path::Path,
+    export_shim_path: &std::path::Path,
+    import_shim_path: &std::path::Path,
 ) -> Result<(), Error> {
+    // export shim
     let mut module = wagen::Module::new();
     let invoke = module.import(
         "core",
@@ -26,6 +28,11 @@ pub(crate) fn generate(
             .export(export);
         elements.push(fn_index.index);
     }
+
+    module.validate_save(&export_shim_path)?;
+
+    // import shim
+    let mut module = wagen::Module::new();
 
     let n_imports = imports.len();
     let import_table = module.tables().push(wagen::TableType {
@@ -82,6 +89,7 @@ pub(crate) fn generate(
         wagen::Elements::Functions(&import_elements),
     );
 
-    module.validate_save(&shim_path)?;
+    module.validate_save(&import_shim_path)?;
+
     Ok(())
 }

--- a/lib/src/py_module.rs
+++ b/lib/src/py_module.rs
@@ -356,7 +356,7 @@ pub fn make_extism_ffi_module(py: Python<'_>, module: &Bound<'_, PyModule>) -> P
     Ok(())
 }
 
-#[link(wasm_import_module = "shim")]
+#[link(wasm_import_module = "import_shim")]
 extern "C" {
     // this import will get satisified by the import shim
     fn __invokeHostFunc_0_0(func_idx: u32);


### PR DESCRIPTION
See my EIP for more details on this

## How this experiment works

The way this compiler currently works is it builds a shim.wasm and a core.wasm. The shim had both the export and the import shims in it. This works fine when using wasm-merge, but creates a circular dependency when trying to dynamically load the modules. So i moved the imports into their own module. They could maybe be wasm-merged with core.wasm though?

When compiling count-vowels.wasm e.g., we get 3 modules in our build directory (hard coded to my home directory ~/py-out):

```
$ ls
core.wasm  import_shim.wasm  main.wasm
```

`core.wasm` exports the `__invoke`:

```
$ wasm-objdump core.wasm --section=Export -x

core.wasm:	file format wasm 0x1

Section Details:

Export[3]:
 - memory[0] -> "memory"
 - func[11050] <__invoke> -> "__invoke"
 - func[11052] <PyInit_extism_ffi> -> "PyInit_extism_ffi"
 ```

`import.wasm` just has the `__invokeHostFunc*` exports.

`main.wasm` has the final export:

```
$ wasm-objdump main.wasm --section=Export -x

main.wasm:	file format wasm 0x1

Section Details:

Export[1]:
 - func[1] <count_vowels> -> "count_vowels"
```

These all get wasm-merged together in the end. But i left the build directory so i could try dynamically linking them. And it works:

```
$ extism call main.wasm count_vowels --input="Hello World" --link import_shim=import_shim.wasm --link core=./core.wasm  --wasi
{"count": 3}
```




