### PR TITLE
cleanup: remove custom json

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,28 +189,11 @@ extism call plugin.wasm sum --input='{"a": 20, "b": 21}' --wasi
 # => {"sum":41}
 ```
 
-You can also specify your input and output types as dataclasses using
-`extism.Json`:
-
-```python
-from typing import Optional, List 
-from dataclasses import dataclass
-
-# ...
-
-@dataclass
-class User(extism.Json):
-  admin: bool
-  name: Optional[str]
-  email: str
-  addresses: List[Address]
-
-
-@extism.plugin_fn
-def reflect_user():
-  input = extism.input(User)
-  extism.output(input)
-```
+For automatic deserialization of input types and serialization of output types,
+see [XTP Python Bindgen](https://github.com/dylibso/xtp-python-bindgen/) . The
+`extism.Json` dataclass serialization has been removed in-favor of the
+[Dataclass Wizard](https://dataclass-wizard.readthedocs.io/en/latest/index.html)
+based solution there.
 
 ### Configs
 

--- a/examples/count-vowels.py
+++ b/examples/count-vowels.py
@@ -1,10 +1,4 @@
 import extism
-import json
-from dataclasses import dataclass
-
-@dataclass
-class Count(extism.Json):
-    count: int
 
 @extism.plugin_fn
 def count_vowels():
@@ -14,5 +8,5 @@ def count_vowels():
         if ch in ['A', 'a', 'E', 'e', 'I', 'i', 'O', 'o', 'U', 'u']:
             total += 1
     extism.log(extism.LogLevel.Info, "Hello!")
-    extism.output(Count(total))
+    extism.output({"count": total})
 

--- a/examples/imports.py
+++ b/examples/imports.py
@@ -1,5 +1,4 @@
 import extism
-import json
 
 @extism.import_fn("example", "do_something")
 def do_something():
@@ -10,7 +9,7 @@ def reflect(x: str) -> str:
     pass
 
 @extism.import_fn("example", "update_dict")
-def update_dict(x: extism.JsonObject) -> extism.JsonObject:
+def update_dict(x: dict) -> dict:
     pass
 
 @extism.plugin_fn


### PR DESCRIPTION
* Fixes #38 (as JSONDecoder is removed)
* Fixes #37 (`issubclass` checks  are now after `list` and `dict` handling.)
* Fixes #22 (as JSONDecoder is removed)