### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/.github/workflows/ci_install.yml
+++ b/.github/workflows/ci_install.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Test Install Script
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         bash ./install.sh
       if: runner.os != 'Windows'

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-py"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
 if [[ -z "${GITHUB_TOKEN}" ]]; then
-  GITHUB_FLAGS=""
+  GITHUB_FLAGS=()
 else
-  GITHUB_FLAGS="--header \"Authorization: Bearer $GITHUB_TOKEN\" --header \"X-GitHub-Api-Version: 2022-11-28\""
+  GITHUB_FLAGS=('--header' "Authorization: Bearer $GITHUB_TOKEN" '--header' 'X-GitHub-Api-Version: 2022-11-28')
 fi
 
 set -eou pipefail
 
 # Get the latest release
 RELEASE_API_URL="https://api.github.com/repos/extism/python-pdk/releases/latest"
-response=$(curl $GITHUB_FLAGS -s "$RELEASE_API_URL")
+if [[ ${#GITHUB_FLAGS[@]} -eq 0 ]]; then
+  response=$(curl -s "$RELEASE_API_URL")
+else
+  response=$(curl "${GITHUB_FLAGS[@]}" -s "$RELEASE_API_URL")
+fi
 if [ -z "$response" ]; then
     echo "Error: Failed to fetch the latest release from GitHub API."
     exit 1

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extism-python-pdk"
-version = "0.1.1"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-pdk"
-version = "0.1.0"
+version = "0.1.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Fixes #34, actually runs with `GITHUB_TOKEN` now