### PR TITLE
fix: prevent env var leaks into WASM output

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -74,6 +74,9 @@ fn main() -> Result<(), Error> {
             .arg(&opts.input_py)
             .arg("-o")
             .arg(&core_path);
+
+        command.env_clear();
+
         if opts.debug {
             command.arg("-g");
         }


### PR DESCRIPTION
Uses `command.env_clear()` prior to spawning plugin compilation process to prevent environment variables from being embedded in the generated WASM binary.

Discovered by evaluating the `.wat` version of the wasm file, and verified the positive effect after the change.